### PR TITLE
New feature: allow filter() method to accept two or three arguments

### DIFF
--- a/d3.network.js
+++ b/d3.network.js
@@ -187,14 +187,30 @@ d3.network = function() {
         return my;
     };
 
-    my.filter = function(edge_cut, node_cut) {
+    // Supports either: filter(min_edge_cut, node_cut)
+    //              or: filter(min_edge_cut, max_edge_cut, node_cut)
+    my.filter = function() {
+        if (argument.length < 2 || argument > 3) {
+            return;
+        }
+
+        var node_cut = argument[argument.length - 1];
+        var min_edge_cut = argument[0];
+        var max_edge_cut;
+        if (argument.length === 2) {
+          max_edge_weight = Number.MAX_VALUE;
+        }
+        else {  // argument.length === 3
+          max_edge_weight = argument[1];
+        }
+            
         var gene_filter = function(d) {
             return d.query || d.rank < node_cut; 
         };
 
         var edge_filter = function(d) {
-            return d.weight > edge_cut && gene_filter(d.target)
-                    && gene_filter(d.source);
+            return d.weight > min_edge_cut && d.weight < max_edge_cut
+                && gene_filter(d.target) && gene_filter(d.source);
         };
         
         draw_genes = genes.filter(gene_filter);

--- a/d3.network.js
+++ b/d3.network.js
@@ -198,10 +198,10 @@ d3.network = function() {
         var min_edge_cut = arguments[0];
         var max_edge_cut;
         if (arguments.length === 2) {
-            max_edge_weight = Number.MAX_VALUE;
+            max_edge_cut = Number.MAX_VALUE;
         }
         else {  // arguments.length === 3
-            max_edge_weight = arguments[1];
+            max_edge_cut = arguments[1];
         }
             
         var gene_filter = function(d) {

--- a/d3.network.js
+++ b/d3.network.js
@@ -190,18 +190,18 @@ d3.network = function() {
     // Supports either: filter(min_edge_cut, node_cut)
     //              or: filter(min_edge_cut, max_edge_cut, node_cut)
     my.filter = function() {
-        if (argument.length < 2 || argument > 3) {
+        if (arguments.length < 2 || arguments.length > 3) {
             return;
         }
 
-        var node_cut = argument[argument.length - 1];
-        var min_edge_cut = argument[0];
+        var node_cut = arguments[arguments.length - 1];
+        var min_edge_cut = arguments[0];
         var max_edge_cut;
-        if (argument.length === 2) {
+        if (arguments.length === 2) {
             max_edge_weight = Number.MAX_VALUE;
         }
         else {  // argument.length === 3
-            max_edge_weight = argument[1];
+            max_edge_weight = arguments[1];
         }
             
         var gene_filter = function(d) {

--- a/d3.network.js
+++ b/d3.network.js
@@ -198,10 +198,10 @@ d3.network = function() {
         var min_edge_cut = argument[0];
         var max_edge_cut;
         if (argument.length === 2) {
-          max_edge_weight = Number.MAX_VALUE;
+            max_edge_weight = Number.MAX_VALUE;
         }
         else {  // argument.length === 3
-          max_edge_weight = argument[1];
+            max_edge_weight = argument[1];
         }
             
         var gene_filter = function(d) {

--- a/d3.network.js
+++ b/d3.network.js
@@ -200,7 +200,7 @@ d3.network = function() {
         if (arguments.length === 2) {
             max_edge_weight = Number.MAX_VALUE;
         }
-        else {  // argument.length === 3
+        else {  // arguments.length === 3
             max_edge_weight = arguments[1];
         }
             


### PR DESCRIPTION
**filter()** method now can be called by either:
```filter(min_edge_cut, node_cut);```
or:
```filter(min_edge_cut, max_edge_cut, node_cut);```